### PR TITLE
iFixit Bundle: add routing include

### DIFF
--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -71,3 +71,7 @@ _liip_imagine:
 
 _apy_jsformvalidation:
     resource: "@APYJsFormValidationBundle/Resources/config/routing/routing.yml"
+
+ifixit_connector:
+    resource: "@iFixitStoreConnector/Resources/config/routing.yml"
+    prefix: /api/rest/ifixit


### PR DESCRIPTION
Now we can add our own responders !

Here's the pull that adds a new controller which is mapped using this included routing file.
https://github.com/iFixit/ifixit/pull/34646