### PR TITLE
Feature: Product Edit Page Redirector

### DIFF
--- a/config/packages/security.yml
+++ b/config/packages/security.yml
@@ -46,10 +46,6 @@ security:
             pattern:                        ^/api/rest/v1$
             security:                       false
 
-        redirector:
-            pattern:                        ^/api/rest/ifixit/redirect
-            security:                       false
-
         api:
             pattern:                        ^/api
             fos_oauth:                      true

--- a/config/packages/security.yml
+++ b/config/packages/security.yml
@@ -46,6 +46,10 @@ security:
             pattern:                        ^/api/rest/v1$
             security:                       false
 
+        redirector:
+            pattern:                        ^/api/rest/ifixit/redirect
+            security:                       false
+
         api:
             pattern:                        ^/api
             fos_oauth:                      true

--- a/config/routes/routes.yml
+++ b/config/routes/routes.yml
@@ -1,3 +1,2 @@
 ifixit_bundle:
     resource: '@iFixitAkeneoBundle/Resources/config/routing.yml'
-    prefix: '/api/rest/ifixit'

--- a/config/routes/routes.yml
+++ b/config/routes/routes.yml
@@ -1,0 +1,3 @@
+ifixit_bundle:
+    resource: '@iFixitAkeneoBundle/Resources/config/routing.yml'
+    prefix: '/api/rest/ifixit'

--- a/src/iFixit/Controller/EditPageRedirectorController.php
+++ b/src/iFixit/Controller/EditPageRedirectorController.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types = 1);
+
+namespace iFixit\Akeneo\iFixitBundle\Controller;
+
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Akeneo\Pim\Enrichment\Component\Product\Repository\ProductModelRepositoryInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Repository\ProductRepositoryInterface;
+
+class EditPageRedirectorController {
+   /** @var ProductModelRepositoryInterface */
+   protected $modelRepository;
+
+   /** @var ProductRepositoryInterface */
+   protected $productRepository;
+
+   public function __construct(
+      ProductModelRepositoryInterface $modelRepository,
+      ProductRepositoryInterface $productRepository
+   ) {
+      $this->modelRepository = $modelRepository;
+      $this->productRepository = $productRepository;
+   }
+
+   public function redirectToProduct($sku): Response {
+      $product = $this->productRepository->findOneByIdentifier($sku);
+      if (!$product) {
+         throw new \NotFoundHttpException("Product {$sku} not found");
+      }
+      return new RedirectResponse("/#/enrich/product/{$product->getId()}");
+   }
+
+   public function redirectToProductModel($productcode): Response {
+      $productModel = $this->modelRepository->findOneByIdentifier($productcode);
+      if (!$productModel) {
+         throw new \NotFoundHttpException("Product {$productcode} not found");
+      }
+      return new RedirectResponse("/#/enrich/product-model/{$productModel->getId()}");
+   }
+}

--- a/src/iFixit/Resources/config/controllers.yml
+++ b/src/iFixit/Resources/config/controllers.yml
@@ -5,3 +5,9 @@ services:
          - '@pim_catalog.repository.group'
          - '@pim_catalog.factory.group'
          - '@pim_catalog.saver.group'
+   ifixit_akeneo.edit_page_redirector.controller:
+      public: true
+      class: iFixit\Akeneo\iFixitBundle\Controller\EditPageRedirectorController
+      arguments:
+         - '@pim_catalog.repository.product_model'
+         - '@pim_catalog.repository.product'

--- a/src/iFixit/Resources/config/routing.yml
+++ b/src/iFixit/Resources/config/routing.yml
@@ -1,5 +1,5 @@
 clone_product_model:
-    path: /clone_product_model
+    path: /api/rest/ifixit/clone_product_model
     defaults: { _controller: ifixit_akeneo.clone_product_model.controller:cloneProductModel, _format: json }
     methods: [POST]
 edit_product_redirector:

--- a/src/iFixit/Resources/config/routing.yml
+++ b/src/iFixit/Resources/config/routing.yml
@@ -2,3 +2,15 @@ clone_product_model:
     path: /clone_product_model
     defaults: { _controller: ifixit_akeneo.clone_product_model.controller:cloneProductModel, _format: json }
     methods: [POST]
+edit_product_redirector:
+    path: /redirect/edit/product/{sku}
+    controller: ifixit_akeneo.edit_page_redirector.controller::redirectToProduct
+    methods: [GET]
+    requirements:
+        sku: \d{7,8}
+edit_product_model_redirector:
+    path: /redirect/edit/product/{productcode}
+    controller: ifixit_akeneo.edit_page_redirector.controller::redirectToProductModel
+    methods: [GET]
+    requirements:
+        productcode: \d{6}


### PR DESCRIPTION
Akeneo doesn't have a way to open the product edit page based on a
product's sku, or a product-model's code. Without this, the only way to
do it is via the cumbersome UI.

Here we add a new controller that only serves to redirect the browser
to the appropriate edit page of the given sku or productcode.

Note: we use one url, but route to different methods based on the length
of the parameter