### PR TITLE
PostSave: listen to events from AttributeOptions

### DIFF
--- a/src/iFixit/EventListener/PostRemoveListener.php
+++ b/src/iFixit/EventListener/PostRemoveListener.php
@@ -3,8 +3,9 @@
 namespace iFixit\Akeneo\iFixitBundle\EventListener;
 
 use Symfony\Component\EventDispatcher\GenericEvent;
-use Pim\Component\Catalog\Model\ProductInterface;
-use Pim\Component\Catalog\Model\AttributeInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+use Akeneo\Pim\Structure\Component\Model\AttributeOptionInterface;
 
 class PostRemoveListener {
    /** @var iFixitApi */
@@ -25,6 +26,10 @@ class PostRemoveListener {
          case $subject instanceof AttributeInterface:
             $code = $subject->getCode();
             $this->ifixitApi->post("admin/akeneo/attribute_removed", ['code' => $code]);
+            break;
+         case $subject instanceof AttributeOptionInterface:
+            $code = $subject->getAttribute()->getCode();
+            $this->ifixitApi->post("admin/akeneo/attribute_changed", ['code' => $code]);
             break;
          default:
             return;

--- a/src/iFixit/EventListener/PostSaveListener.php
+++ b/src/iFixit/EventListener/PostSaveListener.php
@@ -8,6 +8,7 @@ use Symfony\Component\EventDispatcher\GenericEvent;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+use Akeneo\Pim\Structure\Component\Model\AttributeOptionInterface;
 use Psr\Log\LoggerInterface;
 
 class PostSaveListener {
@@ -76,6 +77,9 @@ class PostSaveListener {
             break;
          case $subject instanceof AttributeInterface:
             $this->notifyAttributeChanged($subject);
+            break;
+         case $subject instanceof AttributeOptionInterface:
+            $this->notifyAttributeChanged($subject->getAttribute());
             break;
       }
    }


### PR DESCRIPTION
When you edit just one of the options of an akeneo simple select
attribute, the only post-save events you get are for the Option,
not the Attribute itself.

So, here we start listening to these events and extracting the relevant
info. Our app handles refreshing the info for an entire attribute
so we can send the same type of "attribute changed" notification.

Closes iFixit/ifixit#35762