### PR TITLE
Akeneo Price Imports: update, don't overwrite prices

### DIFF
--- a/src/iFixit/Akeneo/PriceCollectionAttributeSetter.php
+++ b/src/iFixit/Akeneo/PriceCollectionAttributeSetter.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace iFixit\Akeneo;
+
+use Akeneo\Pim\Enrichment\Component\Product\Builder\EntityWithValuesBuilderInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithValuesInterface;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Updater\Adder\PriceCollectionAttributeAdder;
+use Akeneo\Pim\Enrichment\Component\Product\Updater\Setter\AbstractAttributeSetter;
+
+class PriceCollectionAttributeSetter extends AbstractAttributeSetter {
+   /** @var PriceCollectionAttributeAdder */
+   protected $priceAdder;
+
+   /**
+    * @param EntityWithValuesBuilderInterface $entityWithValuesBuilder
+    * @param PriceCollectionAttributeAdder $priceAdder
+    * @param string[] $supportedTypes
+    */
+   public function __construct(
+      EntityWithValuesBuilderInterface $entityWithValuesBuilder,
+      PriceCollectionAttributeAdder $priceAdder,
+      array $supportedTypes
+   ) {
+      parent::__construct($entityWithValuesBuilder);
+      $this->priceAdder = $priceAdder;
+      $this->supportedTypes = $supportedTypes;
+   }
+
+   /**
+    * {@inheritdoc}
+    */
+   public function setAttributeData(
+       EntityWithValuesInterface $entityWithValues,
+       AttributeInterface $attribute,
+       $data,
+       array $options = []
+   ) {
+      $options = $this->resolver->resolve($options);
+      $this->priceAdder->addAttributeData($entityWithValues, $attribute, $data, $options);
+   }
+}

--- a/src/iFixit/Resources/config/services.yml
+++ b/src/iFixit/Resources/config/services.yml
@@ -24,3 +24,12 @@ services:
 
    ifixit_akeneo.config:
       class: iFixit\Akeneo\iFixitBundle\iFixitConfig
+
+   pim_catalog.updater.setter.price_collection_value:
+      class: iFixit\Akeneo\PriceCollectionAttributeSetter
+      parent: pim_catalog.updater.setter.abstract
+      arguments:
+         - '@pim_catalog.updater.adder.price_collection_value'
+         - ['pim_catalog_price_collection']
+      tags:
+         - { name: 'pim_catalog.updater.setter' }


### PR DESCRIPTION
Problem:
When importing (via a CSV) a price in a particular currency, the import
sets all other currencies to null. Effectively the "value" of a price
attribute is a collection of currency -> value mappings and setting one
of them via a CSV replaces the whole mapping.

Solution:
Use a custom "Setter" (used in imports) that wraps the PriceCollection
"Updater" (used by Mass Edit) which does update individual currencies in
place. Also, use DI to replace the akeneo provided importer with our own.

Closes iFixit/ifixit#36433