### PR TITLE
Docker-compose: add restart policy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - './config/services/akeneo-custom-php.ini:/etc/php/7.3/fpm/conf.d/9a-akeneo-custom.ini'
     working_dir: '/srv/pim'
     command: 'php-fpm -F'
+    restart: always
     networks:
       - 'pim'
 
@@ -52,6 +53,7 @@ services:
       - './:/srv/pim:ro'
       - './docker/httpd.conf:/usr/local/apache2/conf/httpd.conf:ro'
       - './docker/akeneo.conf:/usr/local/apache2/conf/vhost.conf:ro'
+    restart: always
     networks:
       - 'pim'
 
@@ -64,6 +66,7 @@ services:
       - '${DOCKER_PORT_ELASTICSEARCH:-9210}:9200'
     volumes:
       - './data/elasticsearch:/usr/share/elasticsearch/data'
+    restart: always
     networks:
       - 'pim'
 
@@ -79,6 +82,7 @@ services:
       - './config/services/akeneo-custom-php.ini:/etc/php/7.3/cli/conf.d/9a-akeneo-custom.ini'
     working_dir: '/srv/pim'
     command: 'php bin/console akeneo:batch:job-queue-consumer-daemon'
+    restart: always
     networks:
       - 'pim'
 


### PR DESCRIPTION
If our containers crash or the machine is rebooted, let's make sure that
these containers come back.

The docs weren't abundantly clear, but restart: is for services and
restart_policy: is for docker swarm.

Also, the docs don't mention it, but the option takes an int as well to
denote how many retries are allowed.

cr_req 1