### PR TITLE
Set restart: 'always' for prod docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
 
   fpm:
     build: ./docker
+    restart: 'always'
     environment:
       APP_ENV: '${APP_ENV:-prod}'
     volumes:
@@ -42,6 +43,7 @@ services:
 
   httpd:
     image: 'httpd:2.4'
+    restart: 'always'
     environment:
       APP_ENV: '${APP_ENV:-prod}'
     depends_on:
@@ -57,6 +59,7 @@ services:
 
   elasticsearch:
     image: 'docker.elastic.co/elasticsearch/elasticsearch-oss:7.5.1'
+    restart: 'always'
     environment:
       ES_JAVA_OPTS: '${ES_JAVA_OPTS:--Xms512m -Xmx512m}'
       discovery.type: 'single-node'
@@ -69,6 +72,7 @@ services:
 
   job-consumer:
     build: ./docker
+    restart: 'always'
     environment:
       APP_ENV: '${APP_ENV:-prod}'
     depends_on:


### PR DESCRIPTION
It looks like dockerd restarted, and took the Akeneo stack with it. We should set a restart policy (the default is `no`) for the key akeneo services:
![image](https://user-images.githubusercontent.com/6876047/114592893-4be3ea80-9c40-11eb-8104-230a5e58ad10.png)

Docs ref: https://docs.docker.com/compose/compose-file/compose-file-v3/

CC @danielbeardsley