### PR TITLE
PricesComparator: drop thousands separator

### DIFF
--- a/src/iFixit/Akeneo/PricesComparator.php
+++ b/src/iFixit/Akeneo/PricesComparator.php
@@ -42,7 +42,7 @@ class PricesComparator extends AkeneoPricesComparator {
       foreach ($data['data'] as $price) {
          $dataPrices[$price['currency']] = $price['amount'];
          if (is_numeric($price['amount'])) {
-            $dataPrices[$price['currency']] = number_format($price['amount'], 4);
+            $dataPrices[$price['currency']] = number_format($price['amount'], 4, '.', '');
          }
          // Fill in nulls here so that these two arrays end up with the same
          // keys and thus end up comparable
@@ -53,7 +53,7 @@ class PricesComparator extends AkeneoPricesComparator {
       foreach ($originals['data'] as $price) {
          $originalPrices[$price['currency']] = $price['amount'];
          if (is_numeric($price['amount'])) {
-            $originalPrices[$price['currency']] = number_format($price['amount'], 4);
+            $originalPrices[$price['currency']] = number_format($price['amount'], 4, '.', '');
          }
       }
 


### PR DESCRIPTION
Including the thousands separator in prices that were sent to the
next level ended up failing saves that included a price > 1000 (thus
including a separator).

This class was copied from the akeneo one and slightly modified. In
Akeneo, these values are only used for comparison and thrown away,
accepting the input wholesale or not at all. In our version, they are
used for comparison and value merging, which is why the later stages are
complaining about the formatting.